### PR TITLE
Add metrics_callback to the protocol options.

### DIFF
--- a/lib/plug/cowboy.ex
+++ b/lib/plug/cowboy.ex
@@ -191,7 +191,7 @@ defmodule Plug.Cowboy do
 
   ## Helpers
 
-  @protocol_options [:compress, :stream_handlers]
+  @protocol_options [:compress, :stream_handlers, :metrics_callback]
 
   defp run(scheme, plug, opts, cowboy_options) do
     case Application.ensure_all_started(:cowboy) do


### PR DESCRIPTION
This extra option allows us to pass a function that will handle the metrics that Cowboy generates.
https://github.com/ninenines/cowboy/blob/master/src/cowboy_metrics_h.erl

config :free_license_server, MyApp.Endpoint,
  http: [port: 4000, metrics_callback:  &MyApp.Fun.do_metrics_callback/1, stream_handlers: [:cowboy_metrics_h, :cowboy_stream_h]],
  debug_errors: true,